### PR TITLE
fix(wsh): Send mail error when api parameters are wrong (refs #6535)

### DIFF
--- a/Class/Fdl/ErrorCodeCORE.php
+++ b/Class/Fdl/ErrorCodeCORE.php
@@ -61,6 +61,14 @@ namespace {
          */
         const CORE0012 = "Access deny : %s";
         /**
+         * @errorCode Trying to access a non-existing user account
+         */
+        const CORE0013 = "Error : User [%s] doesn't exists";
+        /**
+         * @errorCode Trying to access a desactivated user account
+         */
+        const CORE0014 = "Error : User account [%s] is desactivated";
+        /**
          * @errorCode
          * for beautifier
          */

--- a/Share/Lib.Main.php
+++ b/Share/Lib.Main.php
@@ -448,14 +448,24 @@ function _wsh_send_error($errMsg, $expand = array())
     $wshError->addExpand($expand);
     $wshError->autosend();
 }
+
 /**
+ * Handle exceptions by logging errors or by sending mails
+ * depending if the program is used in a CLI or not.
+ *
  * @param Throwable $e
+ * @param bool $callStack If set to false: the error message is minimal.
+ * Otherwise the error message is the call stack.
  */
-function _wsh_exception_handler($e)
+function _wsh_exception_handler($e, $callStack = true)
 {
-    $errMsg = formatErrorLogException($e);
-    
-    error_log($errMsg);
+    if ($callStack === true) {
+        $errMsg = formatErrorLogException($e);
+        error_log($errMsg);
+    } else {
+        $errMsg = $e->getMessage();
+    }
+
     if (!isInteractiveCLI()) {
         $expand = array(
             'm' => preg_replace('/^([^\n]*).*/s', '\1', $e->getMessage())


### PR DESCRIPTION
By using cached Exceptions instead of exit(), error mails are sent if
wsh is used in non-interactive mode.