### PR TITLE
feat(DbObj): Check for int32 compatible lock identifier in DbObj::lockPoint() (closes #6938)

### DIFF
--- a/Class/Fdl/ErrorCodeDB.php
+++ b/Class/Fdl/ErrorCodeDB.php
@@ -70,6 +70,11 @@ namespace {
          */
         const DB0011 = 'The lock "%d-%s" must be set inside a savePoint transaction';
         /**
+         * @errorCode Lock identifier is not a valid int32
+         * @see DbObj::lockPoint()
+         */
+        const DB0012 = 'Lock identifier (%s) is not a valid int32';
+        /**
          * @errorCode
          * simple query error
          */
@@ -84,7 +89,6 @@ namespace {
          * simple query error connect
          */
         const DB0102 = 'cannot connect to "%s". Simple query error "%s" for query "%s"';
-
         /**
          * @errorCode  Vault identifier key cannot be generated
          * @see VaultDiskStorage::getNewVaultId

--- a/Share/Class.Dcp_Utils_Types.php
+++ b/Share/Class.Dcp_Utils_Types.php
@@ -1,0 +1,52 @@
+<?php
+namespace Dcp\Utils;
+/**
+ * Architecture specific type manipulation.
+ *
+ * @package Dcp\Utils
+ */
+class Types
+{
+    /**
+     * Convert given string or integer to an int32
+     *
+     * @param string|int $value
+     * @return bool(false)|int Returns an integer in the int32 range or
+     * bool(false) if not a valid integer or an out-of-range integer.
+     */
+    public static function to_int32($value)
+    {
+        if (is_string($value)) {
+            /* Check expected integer format /^-?\d+$/ without regex */
+            if (strlen($value) <= 0 || !ctype_digit(substr($value, ((substr($value, 0, 1) == '-') ? 1 : 0)))) {
+                return false;
+            }
+            /*
+             * Cast string to integer and check for {over,under}flow
+             * by comparing the resulting string with the original string.
+            */
+            $int = (int)$value;
+            if (strcmp($value, (string)$int) !== 0) {
+                return false;
+            }
+            $value = $int;
+        }
+        if (!is_int($value)) {
+            return false;
+        }
+        /*
+         * 32 bits integers are already int32, so they are safe.
+        */
+        if (PHP_INT_SIZE >= 8) {
+            /*
+             * 64 bits integers are problematic and we need to check
+             * they are in the int32 range.
+            */
+            $int32_max = 0x7fffffff;
+            if ($value < - 1 * $int32_max - 1 /* 32 bits PHP_INT_MIN */ || $value > $int32_max /* 32 bits PHP_INT_MAX */) {
+                return false;
+            }
+        }
+        return $value;
+    }
+}


### PR DESCRIPTION
The first argument of DbObj::lockPoint() should be a string or an
integer representing a valid int32 value.

If the value is not a valid int32, an exception with code DB0012 is
thrown.